### PR TITLE
don't run pip --upgrade, too many version issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
     import pykern.pksetup
 except ImportError:
     import pip
-    pip.main(['install', '--upgrade', 'pykern'])
+    pip.main(['install', 'pykern'])
     import pykern.pksetup
 
 


### PR DESCRIPTION
People have to upgrade themselves. It's too messy this way. You get errors like:

```
No such file or directory: '/home/vagrant/.pyenv/versions/2.7.10/lib/python2.7/site-packages/numpy-1.9.3.dist-info/METADATA'
```
